### PR TITLE
ntropy_sdk: Add use of unique requests session to SDK

### DIFF
--- a/ntropy_sdk/ntropy_sdk.py
+++ b/ntropy_sdk/ntropy_sdk.py
@@ -234,12 +234,12 @@ class SDK:
         self.base_url = "https://api.ntropy.network"
         self.retries = 10
         self.token = token
-        self.requests = requests
+        self.session = requests.Session()
         self.logger = logging.getLogger("Ntropy-SDK")
 
     def retry_ratelimited_request(self, method: str, url: str, payload: object):
         for i in range(self.retries):
-            resp = self.requests.request(
+            resp = self.session.request(
                 method,
                 self.base_url + url,
                 json=payload,


### PR DESCRIPTION
:question: What
---
- Replace `SDK.requests` attribute with `SDK.session` and use `requests.Session` instance instead of `requests`

:speech_balloon: Why
---
- Avoid creating one session per request
- Make it possible to add settings for every request (e.g. proxy configuration)