### PR TITLE
Add an API to allow 0 amounts in transactions

### DIFF
--- a/ntropy_sdk/ntropy_sdk.py
+++ b/ntropy_sdk/ntropy_sdk.py
@@ -65,7 +65,7 @@ class Transaction:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
         self.transaction_id = transaction_id
-        if amount <= 0:
+        if amount < 0:
             raise ValueError(
                 "amount must be a positive number. For negative amounts, change the entry_type field."
             )

--- a/ntropy_sdk/ntropy_sdk.py
+++ b/ntropy_sdk/ntropy_sdk.py
@@ -18,6 +18,8 @@ class NtropyBatchError(Exception):
 
 
 class Transaction:
+    _zero_amount_check = True
+
     required_fields = [
         "amount",
         "date",
@@ -65,7 +67,7 @@ class Transaction:
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
         self.transaction_id = transaction_id
-        if amount < 0:
+        if (amount == 0 and self._zero_amount_check) or amount < 0:
             raise ValueError(
                 "amount must be a positive number. For negative amounts, change the entry_type field."
             )
@@ -90,6 +92,14 @@ class Transaction:
         for field in self.required_fields:
             if getattr(self, field) is None:
                 raise ValueError(f"{field} should be set")
+
+    @classmethod
+    def disable_zero_amount_check(cls):
+        cls._zero_amount_check = False
+
+    @classmethod
+    def enable_zero_amount_check(cls):
+        cls._zero_amount_check = True
 
     def __repr__(self):
         return f"Transaction(transaction_id={self.transaction_id}, description={self.description}, amount={self.amount}, entry_type={self.entry_type})"

--- a/ntropy_sdk/test_sdk.py
+++ b/ntropy_sdk/test_sdk.py
@@ -3,6 +3,41 @@ from ntropy_sdk import Transaction
 
 
 class TestSDK(unittest.TestCase):
+    def test_transaction_zero_amount(self):
+        vals = {
+            "description": "foo",
+            "entry_type": "debit",
+            "entity_id": "1",
+        }
+
+        testcases = [
+            (0, True, True),
+            (0, False, False),
+            (-1, True, True),
+            (-1, False, True),
+            (1, False, False),
+            (1, True, False),
+        ]
+        for amount, enabled, should_raise in testcases:
+            print("Testcase:", amount, enabled, should_raise)
+            if enabled:
+                Transaction.enable_zero_amount_check()
+            else:
+                Transaction.disable_zero_amount_check()
+            if should_raise:
+                self.assertRaises(
+                    ValueError,
+                    Transaction,
+                    amount=amount,
+                    **vals,
+                )
+            else:
+                Transaction(
+                    amount=amount,
+                    **vals,
+                )
+        Transaction.enable_zero_amount_check()
+
     def test_transaction_entry_type(self):
         for et in ["incoming", "outgoing", "debit", "credit"]:
             t = Transaction(


### PR DESCRIPTION
Used via:

```python
from ntropy_sdk import Transaction
Transaction.disable_zero_amount_check()
```