### PR TITLE
fix(benchmark): resolve crash when hardcoded_fields not provided

### DIFF
--- a/ntropy_sdk/benchmark.py
+++ b/ntropy_sdk/benchmark.py
@@ -324,7 +324,7 @@ def main():
         args.in_csv_file,
         args.out_csv_file,
         drop_fields=args.drop_fields.split(",") if args.drop_fields else [],
-        hardcode_fields=ast.literal_eval(args.hardcoded_fields),
+        hardcode_fields=ast.literal_eval(args.hardcoded_fields) if (args.hardcoded_fields) else None,
         mapping=ast.literal_eval(args.field_mapping) if args.field_mapping else None,
         ground_truth_merchant_field=args.ground_truth_merchant_field,
         ground_truth_label_field=args.ground_truth_label_field,


### PR DESCRIPTION
- prevented args.hardcoded_fields from being evaluated in case it's not provided