### PR TITLE
Use group_by for account holder creation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,22 +55,18 @@ import pandas as pd
 
 df = pd.DataFrame(data = [[12046.15, '2021-12-13', "AMAZON WEB SERVICES AWS.AMAZON.CO WA Ref5543286P25S: Crd15", 'outgoing', 'USD', 'US', str(uuid.uuid4()), 'business', "Ntropy Network Inc.", "fintech", "ntropy.com"]], columns = ["amount", "date", "description", "entry_type", "iso_currency_code", "country", "account_holder_id", "account_holder_type", "account_holder_name", "account_holder_industry", "account_holder_website"])
 
-account_holders = {}
-
 def create_account_holder(row):
-    if row["account_holder_id"] not in account_holders:
-        account_holders[row["account_holder_id"]] = True
-        sdk.create_account_holder(
-            AccountHolder(
-                id=row["account_holder_id"],
-                type=row["account_holder_type"],
-                name=row.get("account_holder_name"),
-                industry=row.get("account_holder_industry"),
-                website=row.get("account_holder_website"),
-            )
+    sdk.create_account_holder(
+        AccountHolder(
+            id=row["account_holder_id"],
+            type=row["account_holder_type"],
+            name=row.get("account_holder_name"),
+            industry=row.get("account_holder_industry"),
+            website=row.get("account_holder_website"),
         )
+    )
 
-df.apply(create_account_holder, axis=1)
+df.groupby("account_holder_id", as_index=False).first().apply(create_account_holder, axis=1)
 
 enriched_df = sdk.add_transactions(df)
 print("ENRICHED:", enriched_df)

--- a/ntropy_sdk/__init__.py
+++ b/ntropy_sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.2.1"
+__version__ = "4.2.2"
 
 from ntropy_sdk.ntropy_sdk import (
     AccountHolder,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.1
+current_version = 4.2.2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<pre>\d+))?
@@ -22,4 +22,3 @@ universal = 1
 exclude = docs
 
 [aliases]
-

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/ntropy-network/ntropy-sdk",
-    version="4.2.1",
+    version="4.2.2",
     zip_safe=False,
 )


### PR DESCRIPTION
In the changed example we ignore potentially conflicting information (i.e., different account names for the same holder ID), and use the first row per holder ID 