### PR TITLE
Remove params dict from get_params output

### DIFF
--- a/ntropy_sdk/models.py
+++ b/ntropy_sdk/models.py
@@ -177,7 +177,6 @@ class BaseModel(BaseEstimator, ClassifierMixin):
             "sync": self.sync,
             "poll_interval": self.poll_interval,
             "labels_only": self.labels_only,
-            "params": self.params,
         }
 
     def set_params(self, **parameters: Any) -> "BaseModel":


### PR DESCRIPTION
Fixes compatibility with serialization (get, set params) from scikit learn BaseEstimator