### PR TITLE
support for predicted mcc (pydantic style)

### DIFF
--- a/ntropy_sdk/ntropy_sdk.py
+++ b/ntropy_sdk/ntropy_sdk.py
@@ -363,6 +363,9 @@ class EnrichedTransaction(BaseModel):
     transaction_type: Optional[TransactionType] = Field(
         description="Type of the transaction."
     )
+    predicted_mcc: Optional[List[int]] = Field(
+        description="A list of MCC (Merchant Category Code of the merchant, according to ISO 18245) predicted by the model."
+    )
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
Same as https://github.com/ntropy-network/ntropy-sdk/pull/90 but pydantic style