### PR TITLE
Use pydantic v1

### DIFF
--- a/ntropy_sdk/__init__.py
+++ b/ntropy_sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.19.0rc7"
+__version__ = "4.19.0rc8"
 
 from ntropy_sdk.ntropy_sdk import (
     AccountHolder,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.19.0rc7
+current_version = 4.19.0rc8
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<pre>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,13 @@ from setuptools import setup, find_packages
 with open("README.md") as readme_file:
     readme = readme_file.read()
 
-requirements = ["requests", "tqdm", "requests_toolbelt", "pydantic", "tabulate"]
+requirements = [
+    "requests",
+    "tqdm",
+    "requests_toolbelt",
+    "pydantic<2",
+    "tabulate",
+]
 
 EXTRAS_REQUIRE = {
     "models": ["pandas", "scikit-learn", "numpy"],

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/ntropy-network/ntropy-sdk",
-    version="4.19.0rc7",
+    version="4.19.0rc8",
     zip_safe=False,
 )


### PR DESCRIPTION
Pydantic v2 was released recently and we don't specify a version for it, so some things break when v2 is used. This PR restricts Pydantic to <2 until we implement v2 support.