### PR TITLE
Add default None to optional fields

### DIFF
--- a/ntropy_sdk/__init__.py
+++ b/ntropy_sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.3.0"
+__version__ = "5.4.0"
 
 from typing import TYPE_CHECKING, Optional
 

--- a/ntropy_sdk/bank_statements.py
+++ b/ntropy_sdk/bank_statements.py
@@ -34,7 +34,7 @@ class BankStatementJobStatus(str, Enum):
 
 class BankStatementFile(BaseModel):
     no_pages: int
-    size: Optional[int]
+    size: Optional[int] = None
 
 
 class BankStatementError(BaseModel):
@@ -44,7 +44,7 @@ class BankStatementError(BaseModel):
 
 class BankStatementJob(BaseModel):
     id: str
-    name: Optional[str]
+    name: Optional[str] = None
     status: BankStatementJobStatus
     created_at: datetime
     file: BankStatementFile
@@ -65,7 +65,7 @@ class BankStatementTransaction(BaseModel):
     date: date
     entry_type: EntryType
     amount: NonNegativeFloat
-    running_balance: Optional[float]
+    running_balance: Optional[float] = None
     currency: str = Field(
         description="The currency of the transaction in ISO 4217 format"
     )
@@ -93,14 +93,14 @@ class BankStatementTransaction(BaseModel):
 
 
 class BankStatementAccount(BaseModel):
-    number: Optional[str]
-    opening_balance: Optional[float]
-    closing_balance: Optional[float]
-    start_date: Optional[date]
-    end_date: Optional[date]
-    is_balance_reconciled: Optional[bool]
-    total_incoming: Optional[float]
-    total_outgoing: Optional[float]
+    number: Optional[str] = None
+    opening_balance: Optional[float] = None
+    closing_balance: Optional[float] = None
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    is_balance_reconciled: Optional[bool] = None
+    total_incoming: Optional[float] = None
+    total_outgoing: Optional[float] = None
     transactions: List[BankStatementTransaction]
     request_id: Optional[str] = None
 

--- a/ntropy_sdk/entities.py
+++ b/ntropy_sdk/entities.py
@@ -10,10 +10,10 @@ if TYPE_CHECKING:
 
 
 class Entity(BaseModel):
-    id: Optional[str]
-    name: Optional[str]
-    website: Optional[str]
-    logo: Optional[str]
+    id: Optional[str] = None
+    name: Optional[str] = None
+    website: Optional[str] = None
+    logo: Optional[str] = None
     mccs: List[int]
 
 

--- a/ntropy_sdk/reports.py
+++ b/ntropy_sdk/reports.py
@@ -17,7 +17,7 @@ class Report(BaseModel):
     id: str
     created_at: datetime
     status: str
-    rejection_reason: Optional[str]
+    rejection_reason: Optional[str] = None
 
     transaction_id: str
     description: str

--- a/ntropy_sdk/transactions.py
+++ b/ntropy_sdk/transactions.py
@@ -241,7 +241,7 @@ class RecurrenceGroup(BaseModel):
 
 class RecurrenceGroups(BaseModel):
     groups: List[RecurrenceGroup]
-    request_id: Optional[str]
+    request_id: Optional[str] = None
 
 
 class Recurrence(BaseModel):

--- a/ntropy_sdk/v2/bank_statements.py
+++ b/ntropy_sdk/v2/bank_statements.py
@@ -7,20 +7,20 @@ from ntropy_sdk.utils import AccountHolderType
 
 
 class Address(BaseModel):
-    street: Optional[str]
-    postcode: Optional[str]
-    city: Optional[str]
-    state: Optional[str]
-    country: Optional[str]
+    street: Optional[str] = None
+    postcode: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = None
 
     class Config:
         extra = "allow"
 
 
 class AccountHolder(BaseModel):
-    type: Optional[AccountHolderType]
-    name: Optional[str]
-    address: Optional[Address]
+    type: Optional[AccountHolderType] = None
+    name: Optional[str] = None
+    address: Optional[Address] = None
 
     class Config:
         use_enum_values = True
@@ -28,22 +28,22 @@ class AccountHolder(BaseModel):
 
 
 class Account(BaseModel):
-    type: Optional[str]
-    number: Optional[str]
-    opening_balance: Optional[float]
-    closing_balance: Optional[float]
-    iso_currency_code: Optional[str]
+    type: Optional[str] = None
+    number: Optional[str] = None
+    opening_balance: Optional[float] = None
+    closing_balance: Optional[float] = None
+    iso_currency_code: Optional[str] = None
 
     class Config:
         extra = "allow"
 
 
 class StatementInfo(BaseModel):
-    institution: Optional[str]
-    start_date: Optional[date]
-    end_date: Optional[date]
-    account_holder: Optional[AccountHolder]
-    accounts: Optional[List[Account]]
+    institution: Optional[str] = None
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    account_holder: Optional[AccountHolder] = None
+    accounts: Optional[List[Account]] = None
     request_id: str
 
     class Config:

--- a/ntropy_sdk/v2/income_check.py
+++ b/ntropy_sdk/v2/income_check.py
@@ -60,16 +60,16 @@ class IncomeGroup(BaseModel):
     total_amount: float
     iso_currency_code: str
     income_type: str
-    source: Optional[str]
-    merchant_id: Optional[str]
+    source: Optional[str] = None
+    merchant_id: Optional[str] = None
     first_payment_date: str
     latest_payment_date: str
     duration: str
     is_active: bool
     latest_payment_description: str
-    pay_frequency: Optional[str]
-    next_expected_payment_date: Optional[str]
-    next_expected_payment_amount: Optional[str]
+    pay_frequency: Optional[str] = None
+    next_expected_payment_date: Optional[str] = None
+    next_expected_payment_amount: Optional[str] = None
     transaction_ids: List[Union[int, str]]
     transactions: List[Any]  # List[EnrichedTransaction]
 
@@ -95,8 +95,8 @@ class IncomeGroup(BaseModel):
 
 
 class IncomeSummary(BaseModel):
-    main_income_source: Optional[str]
-    main_income_type: Optional[str]
+    main_income_source: Optional[str] = None
+    main_income_type: Optional[str] = None
     total_income: float
     earned_income: float
     passive_income: float

--- a/ntropy_sdk/v2/ntropy_sdk.py
+++ b/ntropy_sdk/v2/ntropy_sdk.py
@@ -986,13 +986,13 @@ class Report(BaseModel):
 
 
 class Statement(BaseModel):
-    begin_date: Optional[date]
-    end_date: Optional[date]
-    begin_balance: Optional[float]
-    end_balance: Optional[float]
-    total_incoming: Optional[float]
-    total_outgoing: Optional[float]
-    is_balance_reconciled: Optional[bool]
+    begin_date: Optional[date] = None
+    end_date: Optional[date] = None
+    begin_balance: Optional[float] = None
+    end_balance: Optional[float] = None
+    total_incoming: Optional[float] = None
+    total_outgoing: Optional[float] = None
+    is_balance_reconciled: Optional[bool] = None
 
 
 class BankStatement(BaseModel):
@@ -1001,7 +1001,7 @@ class BankStatement(BaseModel):
     status: str
     transactions: Optional[List] = []
     account_type: AccountHolderType
-    statements: Optional[List[Statement]]
+    statements: Optional[List[Statement]] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/ntropy_sdk/v2/recurring_payments.py
+++ b/ntropy_sdk/v2/recurring_payments.py
@@ -5,23 +5,23 @@ from tabulate import tabulate
 
 class RecurringPaymentsGroup(BaseModel):
     latest_payment_amount: float
-    periodicity: Optional[str]
-    merchant: Optional[str]
-    merchant_id: Optional[str]
-    website: Optional[str]
-    labels: Optional[List[str]]
-    logo: Optional[str]
+    periodicity: Optional[str] = None
+    merchant: Optional[str] = None
+    merchant_id: Optional[str] = None
+    website: Optional[str] = None
+    labels: Optional[List[str]] = None
+    logo: Optional[str] = None
     type: str
     is_essential: bool
     is_active: bool
     first_payment_date: str
     latest_payment_date: str
-    next_expected_payment_date: Optional[str]
+    next_expected_payment_date: Optional[str] = None
     latest_payment_description: str
     transaction_ids: List[Union[int, str]]
-    transactions: Any  # EnrichedTransactionList
+    transactions: Any = None  # EnrichedTransactionList
     total_amount: float
-    iso_currency_code: Optional[str]
+    iso_currency_code: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]):

--- a/ntropy_sdk/webhooks.py
+++ b/ntropy_sdk/webhooks.py
@@ -44,7 +44,7 @@ class Webhook(BaseModel):
         description="A list of events that this webhook subscribes to",
     )
     token: Optional[str] = Field(
-        description="A secret string used to authenticate the webhook. This "
+        None, description="A secret string used to authenticate the webhook. This "
         "value will be included in the `X-Ntropy-Token` header when sending "
         "requests to the webhook",
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.3.0
+current_version = 5.4.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<pre>\d+))?
@@ -22,3 +22,4 @@ universal = 1
 exclude = docs
 
 [aliases]
+

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/ntropy-network/ntropy-sdk",
-    version="5.3.0",
+    version="5.4.0",
     zip_safe=False,
 )

--- a/tests/v2/test_bank_statements.py
+++ b/tests/v2/test_bank_statements.py
@@ -31,7 +31,7 @@ def test_processed_bank_statement(sdk, bank_statement_sample):
     bsr = BankStatementRequest(
         sdk=sdk,
         filename="file",
-        bs_id="940ee882-cdf1-4770-838b-35e31859b56e",
+        bs_id="cc746f97-4dd7-4810-b602-6531e4139460",
     )
 
     df = bsr.wait()


### PR DESCRIPTION
for pydantic v2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many Pydantic response/request models; while changes are largely default-value semantics, they can affect validation/requiredness and serialized output in client integrations.
> 
> **Overview**
> Bumps the SDK version to `5.4.0`.
> 
> Updates multiple Pydantic models (e.g., bank statements, entities, reports, recurring payments, income check, webhooks, recurrence groups) to set explicit `= None` defaults for `Optional[...]` fields, aligning model required/optional behavior with Pydantic v2 expectations. A v2 bank statement test fixture ID is also updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edb677be5e1bfee94b62c4aa630345b68970fa98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->